### PR TITLE
formsproduct-jenkins to 1.8.0-beta.6

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,4 +9,4 @@ dependencies:
   version: 2.3.89
 - name: formsproduct-jenkins
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.8.0-beta.5
+  version: 1.8.0-beta.6


### PR DESCRIPTION
Promote formsproduct-jenkins to version 1.8.0-beta.6